### PR TITLE
feat: encode single and decode cbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ All messages will be prefixed with a varint.
 
 Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`BufferList`](https://www.npmjs.com/package/bl) objects.
 
+### `encode.single(chunk)`
+
+- `chunk: Buffer|BufferList` chunk to encode
+
+Returns a `BufferList` containing the encoded chunk.
+
 ### `decode([opts])`
 
 - `opts: Object`, optional
   - `maxDataLength`: If provided, will not decode messages longer than the size specified, if omitted will use the current default of 4MB.
+  - `onLength(len: Number)`: Called for every length prefix that is decoded from the stream
+  - `onData(data: BufferList)`: Called for every chunk of data that is decoded from the stream
 
 All messages will be prefixed with a varint.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "it-length-prefixed",
-  "version": "1.3.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3420,10 +3420,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -3794,14 +3793,12 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.3.0.tgz",
+      "integrity": "sha512-XykNc84nIOC32vZ9euOKbmGAP69JUkXDtBQfLq88c8/6J/gZi/t14A+l/p/9EM2TcT5xNC1MKPCrvO3LVUpVPw==",
       "requires": {
         "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -9953,10 +9950,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-      "dev": true
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -11601,6 +11597,14 @@
       "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+          "dev": true
+        }
       }
     },
     "map-cache": {
@@ -12302,6 +12306,17 @@
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -13779,9 +13794,9 @@
       "dev": true
     },
     "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
       "dev": true
     },
     "p-finally": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/alanshaw/it-length-prefixed#readme",
   "dependencies": {
     "bl": "^3.0.0",
+    "buffer": "^5.3.0",
     "varint": "^5.0.0"
   },
   "devDependencies": {
@@ -43,6 +44,7 @@
     "it-block": "^1.0.1",
     "it-pipe": "^1.0.1",
     "it-pushable": "^1.2.1",
+    "p-defer": "^3.0.0",
     "random-bytes": "^1.0.0",
     "random-int": "^2.0.0",
     "streaming-iterables": "^4.1.0"

--- a/src/decode.js
+++ b/src/decode.js
@@ -46,7 +46,10 @@ const ReadHandlers = {
     chunk = buffer.shallowSlice(endByteIndex + 1)
     buffer = new BufferList()
 
+    if (options.onLength) options.onLength(dataLength)
+
     if (dataLength <= 0) {
+      if (options.onData) options.onData(Empty)
       return { mode: ReadModes.LENGTH, chunk, buffer, data: Empty }
     }
 
@@ -67,6 +70,7 @@ const ReadHandlers = {
     chunk = buffer.length > dataLength ? buffer.shallowSlice(dataLength) : null
     buffer = new BufferList()
 
+    if (options.onData) options.onData(data)
     return { mode: ReadModes.LENGTH, chunk, buffer, data }
   }
 }

--- a/src/encode.js
+++ b/src/encode.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Varint = require('varint')
+const { Buffer } = require('buffer')
 const BufferList = require('bl')
 
 const MIN_POOL_SIZE = 147 // Varint.encode(Number.MAX_VALUE).length
@@ -29,6 +30,8 @@ function encode (options) {
     }
   })()
 }
+
+encode.single = c => new BufferList([Buffer.from(Varint.encode(c.length)), c])
 
 module.exports = encode
 module.exports.MIN_POOL_SIZE = MIN_POOL_SIZE

--- a/test/encode.single.spec.js
+++ b/test/encode.single.spec.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const randomInt = require('random-int')
+const randomBytes = require('random-bytes')
+const Varint = require('varint')
+
+const lp = require('../')
+const someBytes = n => randomBytes(randomInt(1, n || 32))
+
+describe('encode.single', () => {
+  it('should encode length as prefix', async () => {
+    const input = await someBytes()
+    const output = lp.encode.single(input)
+
+    const length = Varint.decode(output.slice())
+    expect(length).to.equal(input.length)
+    expect(output.slice(Varint.decode.bytes)).to.deep.equal(input)
+  })
+
+  it('should encode zero length as prefix', async () => {
+    const input = Buffer.alloc(0)
+    const output = lp.encode.single(input)
+
+    const length = Varint.decode(output.slice())
+    expect(length).to.equal(input.length)
+    expect(output.slice(Varint.decode.bytes)).to.deep.equal(input)
+  })
+})


### PR DESCRIPTION
Adds `encode.single` for encoding a single chunk with a varint length prefix.

Adds `onLength` and `onData` optional callbacks for `decode` that are called each time a length prefix or data chunk are decoded from the stream.