### PR TITLE
feat: custom length encoding

### DIFF
--- a/src/encode.js
+++ b/src/encode.js
@@ -7,8 +7,17 @@ const BufferList = require('bl/BufferList')
 const MIN_POOL_SIZE = 147 // Varint.encode(Number.MAX_VALUE).length
 const DEFAULT_POOL_SIZE = 10 * 1024
 
+// Encode the passed length `value` to the `target` buffer at the given `offset`
+const lengthEncoder = (value, target, offset) => {
+  const ret = Varint.encode(value, target, offset)
+  lengthEncoder.bytes = Varint.encode.bytes
+  // If no target, create Buffer from returned array
+  return target || Buffer.from(ret)
+}
+
 function encode (options) {
   options = options || {}
+  options.lengthEncoder = options.lengthEncoder || lengthEncoder
   options.poolSize = Math.max(options.poolSize || DEFAULT_POOL_SIZE, MIN_POOL_SIZE)
 
   return source => (async function * () {
@@ -16,9 +25,9 @@ function encode (options) {
     let poolOffset = 0
 
     for await (const chunk of source) {
-      Varint.encode(chunk.length, pool, poolOffset)
-      poolOffset += Varint.encode.bytes
-      const encodedLength = pool.slice(poolOffset - Varint.encode.bytes, poolOffset)
+      options.lengthEncoder(chunk.length, pool, poolOffset)
+      const encodedLength = pool.slice(poolOffset, poolOffset + options.lengthEncoder.bytes)
+      poolOffset += options.lengthEncoder.bytes
 
       if (pool.length - poolOffset < MIN_POOL_SIZE) {
         pool = Buffer.alloc(options.poolSize)
@@ -31,7 +40,11 @@ function encode (options) {
   })()
 }
 
-encode.single = c => new BufferList([Buffer.from(Varint.encode(c.length)), c])
+encode.single = (chunk, options) => {
+  options = options || {}
+  options.lengthEncoder = options.lengthEncoder || lengthEncoder
+  return new BufferList([options.lengthEncoder(chunk.length), chunk])
+}
 
 module.exports = encode
 module.exports.MIN_POOL_SIZE = MIN_POOL_SIZE

--- a/test/encode.single.spec.js
+++ b/test/encode.single.spec.js
@@ -27,4 +27,20 @@ describe('encode.single', () => {
     expect(length).to.equal(input.length)
     expect(output.slice(Varint.decode.bytes)).to.deep.equal(input)
   })
+
+  it('should encode with custom length encoder (int32BE)', async () => {
+    const input = await someBytes()
+
+    const lengthEncoder = (value, target, offset) => {
+      target = target || Buffer.allocUnsafe(4)
+      target.writeInt32BE(value, offset)
+      return target
+    }
+    lengthEncoder.bytes = 4 // Always because fixed length
+
+    const output = lp.encode.single(input, { lengthEncoder })
+
+    const length = output.readInt32BE(0)
+    expect(length).to.equal(input.length)
+  })
 })


### PR DESCRIPTION
Still WIP!

@mkg20001 @jacobheun how is this shaping up?

You can pass `encode` and `encode.single` a `lengthEncoder`. This is just a function that works similarly to `varint.encode`.

It is passed a `value` to encode, an (optional) `target` buffer to write to and an (optional) `offset` to start writing from.

The function should encode the `value` into the `target` (or alloc a new Buffer if not specified), set the `lengthEncoder.bytes` value (the number of bytes written) and return the `target`.

I've added a couple of tests showing how this works for int32BE.