### PR TITLE
feat: output buffers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "it-length-prefixed",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/decode.js
+++ b/src/decode.js
@@ -82,7 +82,7 @@ function decode (options) {
       while (chunk) {
         const result = ReadHandlers[mode](chunk, buffer, state, options)
         ;({ mode, chunk, buffer, state } = result)
-        if (result.data) yield result.data
+        if (result.data) yield result.data.slice()
       }
     }
 

--- a/src/encode.js
+++ b/src/encode.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { Buffer } = require('buffer')
-const BufferList = require('bl/BufferList')
 const varintEncode = require('./varint-encode')
 
 const MIN_POOL_SIZE = 8 // Varint.encode(Number.MAX_SAFE_INTEGER).length
@@ -27,8 +26,7 @@ function encode (options) {
         poolOffset = 0
       }
 
-      yield new BufferList().append(encodedLength).append(chunk)
-      // yield Buffer.concat([encodedLength, chunk])
+      yield Buffer.concat([encodedLength, chunk])
     }
   })()
 }
@@ -36,7 +34,7 @@ function encode (options) {
 encode.single = (chunk, options) => {
   options = options || {}
   const encodeLength = options.lengthEncoder || varintEncode
-  return new BufferList([encodeLength(chunk.length), chunk])
+  return Buffer.concat([encodeLength(chunk.length), chunk])
 }
 
 module.exports = encode

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const { map } = require('streaming-iterables')
 const randomInt = require('random-int')
 const randomBytes = require('random-bytes')
 
-module.exports.toBuffer = map(c => c.slice())
 module.exports.times = (n, fn) => Array.from(Array(n), fn)
 module.exports.someBytes = n => randomBytes(randomInt(1, n || 32))

--- a/test/decode.from-reader.spec.js
+++ b/test/decode.from-reader.spec.js
@@ -7,7 +7,7 @@ const { expect } = require('chai')
 const randomBytes = require('random-bytes')
 const { collect } = require('streaming-iterables')
 const Varint = require('varint')
-const { toBuffer, times, someBytes } = require('./_helpers')
+const { times, someBytes } = require('./_helpers')
 
 const lp = require('../')
 
@@ -20,7 +20,6 @@ describe('decode from reader', () => {
 
     const output = await pipe(
       lp.decode.fromReader(reader),
-      toBuffer,
       collect
     )
 
@@ -40,7 +39,6 @@ describe('decode from reader', () => {
     try {
       await pipe(
         lp.decode.fromReader(reader, { maxDataLength: 100 }),
-        toBuffer,
         collect
       )
     } catch (err) {

--- a/test/decode.spec.js
+++ b/test/decode.spec.js
@@ -9,7 +9,7 @@ const { collect } = require('streaming-iterables')
 const Varint = require('varint')
 const BufferList = require('bl/BufferList')
 const defer = require('p-defer')
-const { toBuffer, times } = require('./_helpers')
+const { times } = require('./_helpers')
 
 const lp = require('../')
 const { MAX_LENGTH_LENGTH, MAX_DATA_LENGTH } = lp.decode
@@ -25,7 +25,7 @@ describe('decode', () => {
       bytes
     ])
 
-    const [output] = await pipe([input], lp.decode(), toBuffer, collect)
+    const [output] = await pipe([input], lp.decode(), collect)
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -48,7 +48,7 @@ describe('decode', () => {
       bytes
     ])
 
-    const [output] = await pipe([input], lp.decode(), toBuffer, collect)
+    const [output] = await pipe([input], lp.decode(), collect)
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -64,7 +64,7 @@ describe('decode', () => {
       ])
     ]
 
-    const [output] = await pipe(input, lp.decode(), toBuffer, collect)
+    const [output] = await pipe(input, lp.decode(), collect)
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -80,7 +80,7 @@ describe('decode', () => {
       bytes.slice(1)
     ]
 
-    const [output] = await pipe(input, lp.decode(), toBuffer, collect)
+    const [output] = await pipe(input, lp.decode(), collect)
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -93,7 +93,7 @@ describe('decode', () => {
     const input = [...lengths, bytes]
 
     try {
-      await pipe(input, lp.decode(), toBuffer, collect)
+      await pipe(input, lp.decode(), collect)
     } catch (err) {
       expect(err.code).to.equal('ERR_MSG_LENGTH_TOO_LONG')
       return
@@ -111,7 +111,7 @@ describe('decode', () => {
     ]
 
     try {
-      await pipe(input, lp.decode(), toBuffer, collect)
+      await pipe(input, lp.decode(), collect)
     } catch (err) {
       expect(err.code).to.equal('ERR_MSG_DATA_TOO_LONG')
       return
@@ -138,7 +138,7 @@ describe('decode', () => {
       ])
     ]
 
-    const output = await pipe(input, lp.decode(), toBuffer, collect)
+    const output = await pipe(input, lp.decode(), collect)
     expect(output[0].slice(-byteLength0)).to.deep.equal(bytes0)
     expect(output[1].slice(-byteLength1)).to.deep.equal(bytes1)
   })
@@ -221,7 +221,7 @@ describe('decode', () => {
       ])
     ]
 
-    const output = await pipe(input, lp.decode({ lengthDecoder: int32BEDecode }), toBuffer, collect)
+    const output = await pipe(input, lp.decode({ lengthDecoder: int32BEDecode }), collect)
     expect(output[0].slice(-byteLength0)).to.deep.equal(bytes0)
     expect(output[1].slice(-byteLength1)).to.deep.equal(bytes1)
   })

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -7,7 +7,6 @@ const pipe = require('it-pipe')
 const block = require('it-block')
 const Pushable = require('it-pushable')
 const { map, tap, collect } = require('streaming-iterables')
-const { toBuffer } = require('./_helpers')
 
 const lp = require('../')
 const { int32BEEncode, int32BEDecode } = lp
@@ -19,7 +18,7 @@ describe('e2e', () => {
       Buffer.from('world')
     ]
 
-    const encoded = await pipe(input, lp.encode(), toBuffer, collect)
+    const encoded = await pipe(input, lp.encode(), collect)
 
     const helloLen = Varint.encode('hello '.length)
     const worldLen = Varint.encode('world'.length)
@@ -37,7 +36,7 @@ describe('e2e', () => {
       ])
     ])
 
-    const output = await pipe(encoded, lp.decode(), toBuffer, collect)
+    const output = await pipe(encoded, lp.decode(), collect)
 
     expect(input).to.be.eql(output)
   })
@@ -48,7 +47,7 @@ describe('e2e', () => {
       Buffer.from('world')
     ]
 
-    const encoded = await pipe(input, lp.encode(), toBuffer, collect)
+    const encoded = await pipe(input, lp.encode(), collect)
 
     const helloLen = Varint.encode('hello '.length)
     const worldLen = Varint.encode('world'.length)
@@ -77,7 +76,7 @@ describe('e2e', () => {
   })
 
   it('zero length', async () => {
-    const encoded = await pipe([], lp.encode(), toBuffer, collect)
+    const encoded = await pipe([], lp.encode(), collect)
 
     expect(encoded).to.be.eql([])
 
@@ -85,7 +84,6 @@ describe('e2e', () => {
       [Buffer.alloc(0), Buffer.from('more data')],
       lp.encode(),
       lp.decode(),
-      toBuffer,
       collect
     )
 
@@ -117,7 +115,6 @@ describe('e2e', () => {
       p,
       lp.encode(),
       lp.decode(),
-      toBuffer,
       collect
     )
 
@@ -166,7 +163,6 @@ describe('e2e', () => {
         lp.encode(),
         block(size, { noPad: true }),
         lp.decode(),
-        toBuffer,
         collect
       )
 
@@ -200,7 +196,6 @@ describe('e2e', () => {
         delay(10),
         lp.encode(),
         lp.decode(),
-        toBuffer,
         collect
       )
 
@@ -213,7 +208,6 @@ describe('e2e', () => {
         lp.encode(),
         delay(10),
         lp.decode(),
-        toBuffer,
         collect
       )
 
@@ -225,7 +219,6 @@ describe('e2e', () => {
         input,
         lp.encode({ lengthEncoder: int32BEEncode }),
         lp.decode({ lengthDecoder: int32BEDecode }),
-        toBuffer,
         collect
       )
 

--- a/test/encode.spec.js
+++ b/test/encode.spec.js
@@ -6,7 +6,7 @@ const { expect } = require('chai')
 const randomInt = require('random-int')
 const { collect } = require('streaming-iterables')
 const Varint = require('varint')
-const { toBuffer, times, someBytes } = require('./_helpers')
+const { times, someBytes } = require('./_helpers')
 
 const lp = require('../')
 const { int32BEEncode } = lp
@@ -15,7 +15,7 @@ const { MIN_POOL_SIZE } = lp.encode
 describe('encode', () => {
   it('should encode length as prefix', async () => {
     const input = await Promise.all(times(randomInt(1, 10), someBytes))
-    const output = await pipe(input, lp.encode(), toBuffer, collect)
+    const output = await pipe(input, lp.encode(), collect)
     output.forEach((o, i) => {
       const length = Varint.decode(o)
       expect(length).to.equal(input[i].length)
@@ -25,7 +25,7 @@ describe('encode', () => {
 
   it('should encode zero length as prefix', async () => {
     const input = [Buffer.alloc(0)]
-    const output = await pipe(input, lp.encode(), toBuffer, collect)
+    const output = await pipe(input, lp.encode(), collect)
     output.forEach((o, i) => {
       const length = Varint.decode(o)
       expect(length).to.equal(input[i].length)
@@ -38,7 +38,6 @@ describe('encode', () => {
     const output = await pipe(
       input,
       lp.encode({ poolSize: MIN_POOL_SIZE * 1.5 }),
-      toBuffer,
       collect
     )
     output.forEach((o, i) => {
@@ -53,7 +52,6 @@ describe('encode', () => {
     const output = await pipe(
       input,
       lp.encode({ lengthEncoder: int32BEEncode }),
-      toBuffer,
       collect
     )
     output.forEach((o, i) => {


### PR DESCRIPTION
This PR changes the output to buffers to avoid  https://github.com/mkg20001/it-pb-rpc/blob/master/src/index.js#L46 or https://github.com/libp2p/js-libp2p-secio/blob/ef5f09d22034db45ed455b9f31eba944e19a2f75/src/handshake/finish.js#L27-L37 or any other way to transform bufferlist to buffer.

IMO using bufferlist internaly to avoid concat is enough.