### PR TITLE
fix: options are optional

### DIFF
--- a/src/decode.js
+++ b/src/decode.js
@@ -86,7 +86,7 @@ const ReadHandlers = {
 }
 
 /**
- * @param {any} options
+ * @param {any} [options]
  */
 function decode (options) {
   options = options || {}
@@ -140,7 +140,7 @@ function decode (options) {
 
 /**
  * @param {*} reader
- * @param {import('./types').DecoderOptions} options
+ * @param {import('./types').DecoderOptions} [options]
  * @returns
  */
 decode.fromReader = (reader, options) => {

--- a/src/encode.js
+++ b/src/encode.js
@@ -9,7 +9,7 @@ const MIN_POOL_SIZE = 8 // Varint.encode(Number.MAX_SAFE_INTEGER).length
 const DEFAULT_POOL_SIZE = 10 * 1024
 
 /**
- * @param {import('./types').EncoderOptions} options
+ * @param {import('./types').EncoderOptions} [options]
  */
 function encode (options) {
   options = options || {}
@@ -44,7 +44,7 @@ function encode (options) {
 
 /**
  * @param {BufferList | Buffer} chunk
- * @param {import('./types').EncoderOptions} options
+ * @param {import('./types').EncoderOptions} [options]
  */
 encode.single = (chunk, options) => {
   options = options || {}


### PR DESCRIPTION
Options for decode and encode are optional. This creates typescript errors in libp2p unless we provide options

cc @alanshaw 