### PR TITLE
fix: emit uint8arrays

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -106,8 +106,8 @@ const ReadHandlers: Record<string, ReadHandler> = {
   }
 }
 
-export function decode (options?: DecoderOptions): Transform<BufferList | Uint8Array, BufferList> {
-  const decoder = async function * (source: Source<BufferList | Uint8Array>): Source<BufferList> {
+export function decode (options?: DecoderOptions): Transform<BufferList | Uint8Array, Uint8Array> {
+  const decoder = async function * (source: Source<BufferList | Uint8Array>): Source<Uint8Array> {
     let buffer = new BufferList()
     let mode = ReadModes.LENGTH // current parsing mode
     let state: ReadState | undefined // accumulated state for the current mode
@@ -127,7 +127,7 @@ export function decode (options?: DecoderOptions): Transform<BufferList | Uint8A
         state = result.state
 
         if (result.data != null) {
-          yield result.data
+          yield result.data.slice()
         }
       }
     }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -11,7 +11,7 @@ export interface ReadState {
 
 export interface DecoderOptions {
   lengthDecoder?: LengthDecoderFunction
-  onData?: (data: BufferList | Uint8Array) => void
+  onData?: (data: Uint8Array) => void
   onLength?: (length: number) => void
   maxLengthLength?: number
   maxDataLength?: number
@@ -34,7 +34,7 @@ export const MAX_LENGTH_LENGTH = 8 // Varint.encode(Number.MAX_SAFE_INTEGER).len
 // Maximum length of the data section of the message
 export const MAX_DATA_LENGTH = 1024 * 1024 * 4
 
-const Empty = new BufferList([])
+const empty = new BufferList([])
 const ReadModes = { LENGTH: 'readLength', DATA: 'readData' }
 
 const ReadHandlers: Record<string, ReadHandler> = {
@@ -71,11 +71,7 @@ const ReadHandlers: Record<string, ReadHandler> = {
     }
 
     if (dataLength <= 0) {
-      if (options?.onData != null) {
-        options.onData(Empty)
-      }
-
-      return { mode: ReadModes.LENGTH, chunk, buffer, data: Empty }
+      return { mode: ReadModes.LENGTH, chunk, buffer, data: empty }
     }
 
     return { mode: ReadModes.DATA, chunk, buffer, state: { dataLength }, data: undefined }
@@ -97,10 +93,6 @@ const ReadHandlers: Record<string, ReadHandler> = {
 
     const nextChunk = buffer.length > dataLength ? buffer.shallowSlice(dataLength) : undefined
     buffer = new BufferList()
-
-    if ((options?.onData) != null) {
-      options.onData(data)
-    }
 
     return { mode: ReadModes.LENGTH, chunk: nextChunk, buffer, state: undefined, data }
   }
@@ -127,7 +119,13 @@ export function decode (options?: DecoderOptions): Transform<BufferList | Uint8A
         state = result.state
 
         if (result.data != null) {
-          yield result.data.slice()
+          const data = result.data.slice()
+
+          if (options?.onData != null) {
+            options.onData(data)
+          }
+
+          yield data
         }
       }
     }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,5 +1,6 @@
 import BufferList from 'bl/BufferList.js'
 import { varintEncode } from './varint-encode.js'
+import { concat as uint8ArrayConcat } from 'uint8arrays'
 import type { LengthEncoderFunction } from './varint-encode.js'
 import type { Source, Transform } from 'it-stream-types'
 
@@ -12,13 +13,13 @@ interface EncoderOptions {
 export const MIN_POOL_SIZE = 8 // Varint.encode(Number.MAX_SAFE_INTEGER).length
 export const DEFAULT_POOL_SIZE = 10 * 1024
 
-export function encode (options?: EncoderOptions): Transform<BufferList | Uint8Array, BufferList> {
+export function encode (options?: EncoderOptions): Transform<BufferList | Uint8Array, Uint8Array> {
   options = options ?? {}
 
   const poolSize = Math.max(options.poolSize ?? DEFAULT_POOL_SIZE, options.minPoolSize ?? MIN_POOL_SIZE)
   const encodeLength = options.lengthEncoder ?? varintEncode
 
-  const encoder = async function * (source: Source<BufferList | Uint8Array>): Source<BufferList> {
+  const encoder = async function * (source: Source<BufferList | Uint8Array>): Source<Uint8Array> {
     let pool = new Uint8Array(poolSize)
     let poolOffset = 0
 
@@ -32,9 +33,7 @@ export function encode (options?: EncoderOptions): Transform<BufferList | Uint8A
         poolOffset = 0
       }
 
-      // @ts-expect-error bl types are broken
-      yield new BufferList().append(encodedLength).append(chunk)
-      // yield uint8ArrayConcat([encodedLength, chunk])
+      yield uint8ArrayConcat([encodedLength, chunk.slice()], encodedLength.length + chunk.length)
     }
   }
 

--- a/test/decode.from-reader.spec.ts
+++ b/test/decode.from-reader.spec.ts
@@ -4,7 +4,7 @@ import { reader } from 'it-reader'
 import randomBytes from 'iso-random-stream/src/random.js'
 import all from 'it-all'
 import varint from 'varint'
-import { toBuffer, times, someBytes } from './helpers/index.js'
+import { times, someBytes } from './helpers/index.js'
 import * as lp from '../src/index.js'
 
 describe('decode from reader', () => {
@@ -13,18 +13,16 @@ describe('decode from reader', () => {
     const stream = reader(
       pipe(
         input,
-        lp.encode(),
-        toBuffer
+        lp.encode()
       )
     )
 
     const output = await pipe(
       lp.decode.fromReader(stream),
-      toBuffer,
       async (source) => await all(source)
     )
 
-    expect(output).to.eql(input)
+    expect(output).to.deep.equal(input)
   })
 
   it('should not decode a message that is too long', async () => {
@@ -41,7 +39,6 @@ describe('decode from reader', () => {
     await expect(
       pipe(
         lp.decode.fromReader(stream, { maxDataLength: 100 }),
-        toBuffer,
         async (source) => await all(source)
       )
     ).to.eventually.be.rejected.with.property('code', 'ERR_MSG_DATA_TOO_LONG')

--- a/test/decode.spec.ts
+++ b/test/decode.spec.ts
@@ -160,11 +160,7 @@ describe('decode', () => {
     const onLength = (len: number) => {
       const expectedLength = expectedLengths.shift()
 
-      try {
-        expect(len).to.equal(expectedLength)
-      } catch (err) {
-        return lengthDeferred.reject(err)
-      }
+      expect(len).to.equal(expectedLength)
 
       if (expectedLengths.length === 0) {
         lengthDeferred.resolve()
@@ -174,11 +170,7 @@ describe('decode', () => {
     const onData = (data: BufferList | Uint8Array) => {
       const expectedData = expectedDatas.shift()
 
-      try {
-        expect(data.slice()).to.deep.equal(expectedData)
-      } catch (err) {
-        return dataDeferred.reject(err)
-      }
+      expect(data.slice()).to.deep.equal(expectedData)
 
       if (expectedLengths.length === 0) {
         dataDeferred.resolve()

--- a/test/decode.spec.ts
+++ b/test/decode.spec.ts
@@ -7,7 +7,7 @@ import varint from 'varint'
 import BufferList from 'bl/BufferList.js'
 import defer from 'p-defer'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
-import { toBuffer, times } from './helpers/index.js'
+import { times } from './helpers/index.js'
 import * as lp from '../src/index.js'
 import { MAX_LENGTH_LENGTH, MAX_DATA_LENGTH } from '../src/decode.js'
 
@@ -23,7 +23,7 @@ describe('decode', () => {
       bytes
     ])
 
-    const [output] = await pipe([input], lp.decode(), toBuffer, async (source) => await all(source))
+    const [output] = await pipe([input], lp.decode(), async (source) => await all(source))
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -33,7 +33,7 @@ describe('decode', () => {
       new Uint8Array()
     ])
 
-    const [output] = await pipe([input], lp.decode(), toBuffer, async (source) => await all(source))
+    const [output] = await pipe([input], lp.decode(), async (source) => await all(source))
     expect(output).to.deep.equal(new Uint8Array(0))
   })
 
@@ -48,7 +48,7 @@ describe('decode', () => {
       bytes
     ])
 
-    const [output] = await pipe([input], lp.decode(), toBuffer, async (source) => await all(source))
+    const [output] = await pipe([input], lp.decode(), async (source) => await all(source))
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -64,7 +64,7 @@ describe('decode', () => {
       ])
     ]
 
-    const [output] = await pipe(input, lp.decode(), toBuffer, async (source) => await all(source))
+    const [output] = await pipe(input, lp.decode(), async (source) => await all(source))
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -80,7 +80,7 @@ describe('decode', () => {
       bytes.slice(1)
     ]
 
-    const [output] = await pipe(input, lp.decode(), toBuffer, async (source) => await all(source))
+    const [output] = await pipe(input, lp.decode(), async (source) => await all(source))
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
   })
 
@@ -93,7 +93,7 @@ describe('decode', () => {
     const input = [...lengths, bytes]
 
     await expect(
-      pipe(input, lp.decode(), toBuffer, async (source) => await all(source))
+      pipe(input, lp.decode(), async (source) => await all(source))
     ).to.eventually.be.rejected.with.property('code', 'ERR_MSG_LENGTH_TOO_LONG')
   })
 
@@ -107,7 +107,7 @@ describe('decode', () => {
     ]
 
     await expect(
-      pipe(input, lp.decode(), toBuffer, async (source) => await all(source))
+      pipe(input, lp.decode(), async (source) => await all(source))
     ).to.eventually.be.rejected.with.property('code', 'ERR_MSG_DATA_TOO_LONG')
   })
 
@@ -130,7 +130,7 @@ describe('decode', () => {
       ])
     ]
 
-    const output = await pipe(input, lp.decode(), toBuffer, async (source) => await all(source))
+    const output = await pipe(input, lp.decode(), async (source) => await all(source))
     expect(output[0].slice(-byteLength0)).to.deep.equal(bytes0)
     expect(output[1].slice(-byteLength1)).to.deep.equal(bytes1)
   })
@@ -175,7 +175,7 @@ describe('decode', () => {
       const expectedData = expectedDatas.shift()
 
       try {
-        expect(data.slice()).to.eql(expectedData)
+        expect(data.slice()).to.deep.equal(expectedData)
       } catch (err) {
         return dataDeferred.reject(err)
       }
@@ -215,7 +215,7 @@ describe('decode', () => {
       ])
     ]
 
-    const output = await pipe(input, lp.decode({ lengthDecoder: int32BEDecode }), toBuffer, async (source) => await all(source))
+    const output = await pipe(input, lp.decode({ lengthDecoder: int32BEDecode }), async (source) => await all(source))
     expect(output[0].slice(-byteLength0)).to.deep.equal(bytes0)
     expect(output[1].slice(-byteLength1)).to.deep.equal(bytes1)
   })

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -3,7 +3,6 @@ import varint from 'varint'
 import { pipe } from 'it-pipe'
 import { block } from 'it-block'
 import { pushable } from 'it-pushable'
-import { toBuffer } from './helpers/index.js'
 import all from 'it-all'
 import map from 'it-map'
 import each from 'it-foreach'
@@ -22,7 +21,7 @@ describe('e2e', () => {
       uint8ArrayFromString('world')
     ]
 
-    const encoded = await pipe(input, lp.encode(), toBuffer, async (source) => await all(source))
+    const encoded = await pipe(input, lp.encode(), async (source) => await all(source))
 
     const helloLen = varint.encode('hello '.length)
     const worldLen = varint.encode('world'.length)
@@ -40,7 +39,7 @@ describe('e2e', () => {
       ])
     ])
 
-    const output = await pipe(encoded, lp.decode(), toBuffer, async (source) => await all(source))
+    const output = await pipe(encoded, lp.decode(), async (source) => await all(source))
 
     expect(input).to.be.eql(output)
   })
@@ -51,7 +50,7 @@ describe('e2e', () => {
       uint8ArrayFromString('world')
     ]
 
-    const encoded = await pipe(input, lp.encode(), toBuffer, async (source) => await all(source))
+    const encoded = await pipe(input, lp.encode(), async (source) => await all(source))
 
     const helloLen = varint.encode('hello '.length)
     const worldLen = varint.encode('world'.length)
@@ -75,7 +74,7 @@ describe('e2e', () => {
   })
 
   it('zero length', async () => {
-    const encoded = await pipe([], lp.encode(), toBuffer, async (source) => await all(source))
+    const encoded = await pipe([], lp.encode(), async (source) => await all(source))
 
     expect(encoded).to.be.eql([])
 
@@ -83,7 +82,6 @@ describe('e2e', () => {
       [new Uint8Array(0), uint8ArrayFromString('more data')],
       lp.encode(),
       lp.decode(),
-      toBuffer,
       async (source) => await all(source)
     )
 
@@ -115,7 +113,6 @@ describe('e2e', () => {
       p,
       lp.encode(),
       lp.decode(),
-      toBuffer,
       async (source) => await all(source)
     )
 
@@ -156,10 +153,8 @@ describe('e2e', () => {
       const res = await pipe(
         input,
         lp.encode(),
-        toBuffer,
         block(size, { noPad: true }),
         lp.decode(),
-        toBuffer,
         async (source) => await all(source)
       )
 
@@ -193,7 +188,6 @@ describe('e2e', () => {
         (source) => delay(source, 10),
         lp.encode(),
         lp.decode(),
-        toBuffer,
         async (source) => await all(source)
       )
 
@@ -206,7 +200,6 @@ describe('e2e', () => {
         lp.encode(),
         (source) => delay(source, 10),
         lp.decode(),
-        toBuffer,
         async (source) => await all(source)
       )
 
@@ -218,7 +211,6 @@ describe('e2e', () => {
         input,
         lp.encode({ lengthEncoder: int32BEEncode }),
         lp.decode({ lengthDecoder: int32BEDecode }),
-        toBuffer,
         async (source) => await all(source)
       )
 

--- a/test/encode.spec.ts
+++ b/test/encode.spec.ts
@@ -3,7 +3,7 @@ import { pipe } from 'it-pipe'
 import randomInt from 'random-int'
 import all from 'it-all'
 import varint from 'varint'
-import { toBuffer, times, someBytes } from './helpers/index.js'
+import { times, someBytes } from './helpers/index.js'
 import * as lp from '../src/index.js'
 import { MIN_POOL_SIZE } from '../src/encode.js'
 
@@ -12,7 +12,7 @@ const { int32BEEncode } = lp
 describe('encode', () => {
   it('should encode length as prefix', async () => {
     const input = await Promise.all(times(randomInt(1, 10), someBytes))
-    const output = await pipe(input, lp.encode(), toBuffer, async (source) => await all(source))
+    const output = await pipe(input, lp.encode(), async (source) => await all(source))
     output.forEach((o, i) => {
       const length = varint.decode(o)
       expect(length).to.equal(input[i].length)
@@ -22,7 +22,7 @@ describe('encode', () => {
 
   it('should encode zero length as prefix', async () => {
     const input = [new Uint8Array(0)]
-    const output = await pipe(input, lp.encode(), toBuffer, async (source) => await all(source))
+    const output = await pipe(input, lp.encode(), async (source) => await all(source))
     output.forEach((o, i) => {
       const length = varint.decode(o)
       expect(length).to.equal(input[i].length)
@@ -35,7 +35,6 @@ describe('encode', () => {
     const output = await pipe(
       input,
       lp.encode({ poolSize: MIN_POOL_SIZE * 1.5 }),
-      toBuffer,
       async (source) => await all(source)
     )
     output.forEach((o, i) => {
@@ -50,11 +49,11 @@ describe('encode', () => {
     const output = await pipe(
       input,
       lp.encode({ lengthEncoder: int32BEEncode }),
-      toBuffer,
       async (source) => await all(source)
     )
     output.forEach((o, i) => {
-      const length = o.readInt32BE(0)
+      const view = new DataView(o.buffer, o.byteOffset, o.byteLength)
+      const length = view.getUint32(0, false)
       expect(length).to.equal(input[i].length)
     })
   })

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,12 +1,5 @@
-import type BufferList from 'bl/BufferList'
-import map from 'it-map'
 import randomInt from 'random-int'
 import randomBytes from 'iso-random-stream/src/random.js'
-import type { Source } from 'it-stream-types'
-
-export function toBuffer (source: Source<BufferList>) {
-  return map(source, c => c.slice())
-}
 
 export function times <T> (n: number, fn: (...args: any[]) => T): T[] {
   return Array.from(Array(n)).fill(fn())


### PR DESCRIPTION
Keep buffer lists internal to get the speedup without leaking the types to the rest of the stack.