### PR TITLE
fix: swap bl for uint8arraylist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "04:00"
+    time: "10:00"
   open-pull-requests-limit: 10

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,4 @@
-The MIT License (MIT)
+This project is dual licensed under MIT and Apache-2.0.
 
-Copyright (c) 2016 Friedel Ziegelmayer
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/license-2.0

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ await pipe(
   lp.encode(),
   async source => {
     for await (const chunk of source) {
-      encoded.push(chunk.slice()) // (.slice converts BufferList to Buffer)
+      encoded.push(chunk.slice()) // (.slice converts Uint8ArrayList to Uint8Array)
     }
   }
 )
@@ -42,7 +42,7 @@ await pipe(
   lp.decode(),
   async source => {
     for await (const chunk of source) {
-      decoded.push(chunk.slice()) // (.slice converts BufferList to Buffer)
+      decoded.push(chunk.slice()) // (.slice converts Uint8ArrayList to Uint8Array)
     }
   }
 )
@@ -80,15 +80,15 @@ import {
     - The following additional length encoders are available:
       - **int32BE** - `const { int32BEEncode } = require('it-length-prefixed')`
 
-Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`BufferList`](https://www.npmjs.com/package/bl) objects. All messages will be prefixed with a length, determined by the `lengthEncoder` function.
+Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`Uint8ArrayList`](https://www.npmjs.com/package/uint8arraylist) objects. All messages will be prefixed with a length, determined by the `lengthEncoder` function.
 
 ### `encode.single(chunk, [opts])`
 
-- `chunk: Buffer|BufferList` chunk to encode
+- `chunk: Buffer|Uint8ArrayList` chunk to encode
 - `opts: Object`, optional
     - `lengthEncoder: Function`: See description above. Note that this encoder will _not_ be passed a `target` or `offset` and so will need to allocate a buffer to write to.
 
-Returns a `BufferList` containing the encoded chunk.
+Returns a `Uint8ArrayList` containing the encoded chunk.
 
 ### `decode([opts])`
 
@@ -96,12 +96,12 @@ Returns a `BufferList` containing the encoded chunk.
   - `maxLengthLength`: If provided, will not decode messages whose length section exceeds the size specified, if omitted will use the default of 147 bytes.
   - `maxDataLength`: If provided, will not decode messages whose data section exceeds the size specified, if omitted will use the default of 4MB.
   - `onLength(len: Number)`: Called for every length prefix that is decoded from the stream
-  - `onData(data: BufferList)`: Called for every chunk of data that is decoded from the stream
-  - `lengthDecoder: Function`: A function that decodes the length that prefixes each message. By default this is a [`varint`](https://www.npmjs.com/package/varint) decoder. It is passed some `data` to decode which is a [`BufferList`](https://www.npmjs.com/package/bl). The function should decode the length, set the `lengthDecoder.bytes` value (the number of bytes read) and return the length. If the length cannot be decoded, the function should throw a `RangeError`.
+  - `onData(data: Uint8ArrayList)`: Called for every chunk of data that is decoded from the stream
+  - `lengthDecoder: Function`: A function that decodes the length that prefixes each message. By default this is a [`varint`](https://www.npmjs.com/package/varint) decoder. It is passed some `data` to decode which is a [`Uint8ArrayList`](https://www.npmjs.com/package/uint8arraylist). The function should decode the length, set the `lengthDecoder.bytes` value (the number of bytes read) and return the length. If the length cannot be decoded, the function should throw a `RangeError`.
     - The following additional length decoders are available:
       - **int32BE** - `const { int32BEDecode } = require('it-length-prefixed')`
 
-Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`BufferList`](https://www.npmjs.com/package/bl) objects.
+Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`Uint8ArrayList`](https://www.npmjs.com/package/uint8arraylist) objects.
 
 ### `decode.fromReader(reader, [opts])`
 
@@ -111,10 +111,10 @@ Behaves like `decode` except it only reads the exact number of bytes needed for 
 - `opts: Object`, optional
   - `maxLengthLength`: If provided, will not decode messages whose length section exceeds the size specified, if omitted will use the default of 147 bytes.
   - `maxDataLength`: If provided, will not decode messages whose data section exceeds the size specified, if omitted will use the default of 4MB.
-  - `onData(data: BufferList)`: Called for every chunk of data that is decoded from the stream
+  - `onData(data: Uint8ArrayList)`: Called for every chunk of data that is decoded from the stream
   - `lengthEncoder: Function`: See description above.
 
-Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`BufferList`](https://www.npmjs.com/package/bl) objects.
+Returns a [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) that yields [`Uint8ArrayList`](https://www.npmjs.com/package/uint8arraylist) objects.
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,41 @@
   "name": "it-length-prefixed",
   "version": "6.0.1",
   "description": "Streaming length prefixed buffers with async iterables",
+  "author": "Alan Shaw",
+  "license": "Apache-2.0 OR MIT",
+  "homepage": "https://github.com/alanshaw/it-length-prefixed#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alanshaw/it-length-prefixed.git"
+  },
+  "bugs": {
+    "url": "https://github.com/alanshaw/it-length-prefixed/issues"
+  },
+  "keywords": [
+    "async",
+    "iterable",
+    "iterator",
+    "length-prefixed",
+    "length-prefixed-stream",
+    "varint"
+  ],
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
+  },
   "type": "module",
   "types": "./dist/src/index.d.ts",
   "typesVersions": {
     "*": {
       "*": [
         "*",
-        "*/index",
         "dist/*",
-        "dist/*/index",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
         "dist/src/*",
         "dist/src/*/index"
       ]
@@ -26,11 +52,11 @@
     ".": {
       "import": "./dist/src/index.js"
     },
-    "./encode": {
-      "import": "./dist/src/encode.js"
-    },
     "./decode": {
       "import": "./dist/src/decode.js"
+    },
+    "./encode": {
+      "import": "./dist/src/encode.js"
     }
   },
   "eslintConfig": {
@@ -134,42 +160,23 @@
     "test:electron-main": "npm run test -- -t electron-main",
     "release": "semantic-release"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/alanshaw/it-length-prefixed.git"
-  },
-  "keywords": [
-    "varint",
-    "async",
-    "iterable",
-    "iterator",
-    "length-prefixed-stream",
-    "length-prefixed"
-  ],
-  "author": "Alan Shaw",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/alanshaw/it-length-prefixed/issues"
-  },
-  "homepage": "https://github.com/alanshaw/it-length-prefixed#readme",
   "dependencies": {
-    "bl": "^5.0.0",
     "err-code": "^3.0.1",
     "it-stream-types": "^1.0.4",
+    "uint8arraylist": "^1.2.0",
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@types/bl": "^5.0.1",
     "@types/varint": "^6.0.0",
     "aegir": "^36.1.3",
     "iso-random-stream": "^2.0.0",
     "it-all": "^1.0.6",
-    "it-block": "^4.0.0",
+    "it-block": "^5.0.0",
     "it-foreach": "^0.1.1",
     "it-map": "^1.0.6",
     "it-pipe": "^2.0.2",
     "it-pushable": "^2.0.1",
-    "it-reader": "^4.0.1",
+    "it-reader": "^5.0.0",
     "p-defer": "^4.0.0",
     "random-int": "^3.0.0",
     "uint8arrays": "^3.0.0"

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,4 +1,4 @@
-import BufferList from 'bl/BufferList.js'
+import { Uint8ArrayList } from 'uint8arraylist'
 import { varintEncode } from './varint-encode.js'
 import { concat as uint8ArrayConcat } from 'uint8arrays'
 import type { LengthEncoderFunction } from './varint-encode.js'
@@ -13,13 +13,13 @@ interface EncoderOptions {
 export const MIN_POOL_SIZE = 8 // Varint.encode(Number.MAX_SAFE_INTEGER).length
 export const DEFAULT_POOL_SIZE = 10 * 1024
 
-export function encode (options?: EncoderOptions): Transform<BufferList | Uint8Array, Uint8Array> {
+export function encode (options?: EncoderOptions): Transform<Uint8ArrayList | Uint8Array, Uint8Array> {
   options = options ?? {}
 
   const poolSize = Math.max(options.poolSize ?? DEFAULT_POOL_SIZE, options.minPoolSize ?? MIN_POOL_SIZE)
   const encodeLength = options.lengthEncoder ?? varintEncode
 
-  const encoder = async function * (source: Source<BufferList | Uint8Array>): Source<Uint8Array> {
+  const encoder = async function * (source: Source<Uint8ArrayList | Uint8Array>): Source<Uint8Array> {
     let pool = new Uint8Array(poolSize)
     let poolOffset = 0
 
@@ -40,9 +40,8 @@ export function encode (options?: EncoderOptions): Transform<BufferList | Uint8A
   return encoder
 }
 
-encode.single = (chunk: BufferList | Uint8Array, options?: EncoderOptions) => {
+encode.single = (chunk: Uint8ArrayList | Uint8Array, options?: EncoderOptions) => {
   options = options ?? {}
   const encodeLength = options.lengthEncoder ?? varintEncode
-  // @ts-expect-error bl types are broken
-  return new BufferList([encodeLength(chunk.length), chunk.slice()])
+  return new Uint8ArrayList(...[encodeLength(chunk.length), chunk.slice()])
 }

--- a/src/int32BE-encode.ts
+++ b/src/int32BE-encode.ts
@@ -4,7 +4,7 @@ import type { LengthEncoderFunction } from './varint-encode.js'
 export const int32BEEncode: LengthEncoderFunction = (value, target, offset) => {
   target = target ?? allocUnsafe(4)
   const view = new DataView(target.buffer, target.byteOffset, target.byteLength)
-  view.setInt32(offset, value, false)
+  view.setInt32(offset ?? 0, value, false)
   return target
 }
 int32BEEncode.bytes = 4 // Always because fixed length

--- a/src/varint-encode.ts
+++ b/src/varint-encode.ts
@@ -1,14 +1,15 @@
 import varint from 'varint'
 
 export interface LengthEncoderFunction {
-  (value: number, target: Uint8Array, offset: number): Uint8Array
+  (value: number, target?: Uint8Array, offset?: number): Uint8Array
   bytes: number
 }
 
 /**
  * Encode the passed length `value` to the `target` buffer at the given `offset`
  */
-export const varintEncode: LengthEncoderFunction = (value, target, offset) => {
+export const varintEncode: LengthEncoderFunction = (value, target?, offset?) => {
+  // @ts-expect-error target can be undefined
   const ret = varint.encode(value, target, offset)
   varintEncode.bytes = varint.encode.bytes
   // If no target, create Buffer from returned array

--- a/test/decode.spec.ts
+++ b/test/decode.spec.ts
@@ -4,7 +4,7 @@ import randomInt from 'random-int'
 import randomBytes from 'iso-random-stream/src/random.js'
 import all from 'it-all'
 import varint from 'varint'
-import BufferList from 'bl/BufferList.js'
+import { Uint8ArrayList } from 'uint8arraylist'
 import defer from 'p-defer'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { times } from './helpers/index.js'
@@ -37,16 +37,14 @@ describe('decode', () => {
     expect(output).to.deep.equal(new Uint8Array(0))
   })
 
-  it('should decode single message as BufferList', async () => {
+  it('should decode single message as Uint8ArrayList', async () => {
     const byteLength = randomInt(1, 64)
     const bytes = await randomBytes(byteLength)
 
-    const input = new BufferList([
-      // @ts-expect-error bl types are broken
+    const input = new Uint8ArrayList(
       Uint8Array.from(varint.encode(byteLength)),
-      // @ts-expect-error bl types are broken
       bytes
-    ])
+    )
 
     const [output] = await pipe([input], lp.decode(), async (source) => await all(source))
     expect(output.slice(-byteLength)).to.deep.equal(bytes)
@@ -167,7 +165,7 @@ describe('decode', () => {
       }
     }
 
-    const onData = (data: BufferList | Uint8Array) => {
+    const onData = (data: Uint8ArrayList | Uint8Array) => {
       const expectedData = expectedDatas.shift()
 
       expect(data.slice()).to.deep.equal(expectedData)

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -7,7 +7,7 @@ import all from 'it-all'
 import map from 'it-map'
 import each from 'it-foreach'
 import type { Source } from 'it-stream-types'
-import type BufferList from 'bl/BufferList.js'
+import type { Uint8ArrayList } from 'uint8arraylist'
 import * as lp from '../src/index.js'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -219,6 +219,6 @@ describe('e2e', () => {
   })
 })
 
-function delay (source: Source<Uint8Array | BufferList>, time: number) {
+function delay (source: Source<Uint8Array | Uint8ArrayList>, time: number) {
   return each(source, async () => await new Promise(resolve => setTimeout(resolve, time)))
 }

--- a/test/encode.single.spec.ts
+++ b/test/encode.single.spec.ts
@@ -28,7 +28,8 @@ describe('encode.single', () => {
     const input = await someBytes()
     const output = lp.encode.single(input, { lengthEncoder: int32BEEncode })
 
-    const length = output.readInt32BE(0)
+    const view = new DataView(output.slice().buffer)
+    const length = view.getInt32(0, false)
     expect(length).to.equal(input.length)
   })
 })


### PR DESCRIPTION
`bl` brings the buffer polyfill, node streams deps and a bunch of
other stuff, and has a big API that we don't really use any of.

Swap for the `uint8arraylist` module which only really concentrates
on appending byte arrays, slicing them and consuming bytes from them.

BREAKING CHANGE: where `BufferList`s were returned, now `Uint8ArrayList`s are