### PR TITLE
fix: do not create an array to pass in to uint8arraylist

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -43,5 +43,5 @@ export function encode (options?: EncoderOptions): Transform<Uint8ArrayList | Ui
 encode.single = (chunk: Uint8ArrayList | Uint8Array, options?: EncoderOptions) => {
   options = options ?? {}
   const encodeLength = options.lengthEncoder ?? varintEncode
-  return new Uint8ArrayList(...[encodeLength(chunk.length), chunk.slice()])
+  return new Uint8ArrayList(encodeLength(chunk.length), chunk.slice())
 }


### PR DESCRIPTION
Tiny fix but there's no need to create an array and then immediately spread it, we can just pass the items in directly.