### PR TITLE
fix: output uint8arrays

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -19,18 +19,16 @@ const defaultEncoder: LengthEncoderFunction = (length) => {
 }
 defaultEncoder.bytes = 0
 
-export function encode (options?: EncoderOptions): Transform<Uint8ArrayList | Uint8Array, Uint8ArrayList> {
+export function encode (options?: EncoderOptions): Transform<Uint8ArrayList | Uint8Array, Uint8Array> {
   options = options ?? {}
 
   const encodeLength = options.lengthEncoder ?? defaultEncoder
 
-  const encoder = async function * (source: Source<Uint8ArrayList | Uint8Array>): Source<Uint8ArrayList> {
+  const encoder = async function * (source: Source<Uint8ArrayList | Uint8Array>): Source<Uint8Array> {
     for await (const chunk of source) {
       // length + data
-      yield new Uint8ArrayList(
-        encodeLength(chunk.byteLength),
-        chunk
-      )
+      yield encodeLength(chunk.byteLength).subarray()
+      yield chunk
     }
   }
 

--- a/test/encode.spec.ts
+++ b/test/encode.spec.ts
@@ -10,22 +10,38 @@ import { int32BEEncode } from './helpers/int32BE-encode.js'
 describe('encode', () => {
   it('should encode length as prefix', async () => {
     const input = await Promise.all(times(randomInt(1, 10), someBytes))
-    const output = await pipe(input, lp.encode(), async (source) => await all(source))
-    output.forEach((o, i) => {
-      const length = unsigned.decode(o)
-      expect(length).to.equal(input[i].length)
-      expect(o.slice(unsigned.encodingLength(length))).to.deep.equal(input[i])
-    })
+    const output = await pipe(
+      input,
+      lp.encode(),
+      async (source) => await all(source)
+    )
+
+    let inputIndex = 0
+
+    for (let i = 0; i < output.length; i += 2, inputIndex++) {
+      const prefix = output[i]
+      const data = output[i + 1]
+
+      const length = unsigned.decode(prefix)
+      expect(length).to.equal(data.length)
+      expect(data).to.deep.equal(input[inputIndex])
+    }
   })
 
   it('should encode zero length as prefix', async () => {
     const input = [new Uint8Array(0)]
     const output = await pipe(input, lp.encode(), async (source) => await all(source))
-    output.forEach((o, i) => {
-      const length = unsigned.decode(o)
-      expect(length).to.equal(input[i].length)
-      expect(o.slice(unsigned.encodingLength(length))).to.deep.equal(input[i])
-    })
+
+    let inputIndex = 0
+
+    for (let i = 0; i < output.length; i += 2, inputIndex++) {
+      const prefix = output[i]
+      const data = output[i + 1]
+
+      const length = unsigned.decode(prefix)
+      expect(length).to.equal(data.length)
+      expect(data).to.deep.equal(input[inputIndex])
+    }
   })
 
   it('should encode with custom length encoder (int32BE)', async () => {
@@ -35,9 +51,17 @@ describe('encode', () => {
       lp.encode({ lengthEncoder: int32BEEncode }),
       async (source) => await all(source)
     )
-    output.forEach((o, i) => {
-      const length = o.getUint32(0, false)
-      expect(length).to.equal(input[i].length)
-    })
+
+    let inputIndex = 0
+
+    for (let i = 0; i < output.length; i += 2, inputIndex++) {
+      const prefix = output[i]
+      const data = output[i + 1]
+
+      const view = new DataView(prefix.buffer)
+      const length = view.getUint32(0, false)
+      expect(length).to.equal(data.length)
+      expect(length).to.equal(input[inputIndex].length)
+    }
   })
 })


### PR DESCRIPTION
In order to pipe lp.encode output straight to sockets, etc, output
individual uint8arrays instead of wrapping them in a list.