### PR TITLE
fix: export option types

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -5,29 +5,9 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { MAX_DATA_LENGTH, MAX_LENGTH_LENGTH } from './constants.js'
 import { InvalidDataLengthError, InvalidDataLengthLengthError, InvalidMessageLengthError, UnexpectedEOFError } from './errors.js'
 import { isAsyncIterable } from './utils.js'
-import type { LengthDecoderFunction } from './index.js'
+import type { DecoderOptions, LengthDecoderFunction } from './index.js'
 import type { Reader } from 'it-reader'
 import type { Source } from 'it-stream-types'
-
-export interface ReadState {
-  dataLength: number
-}
-
-export interface DecoderOptions {
-  lengthDecoder?: LengthDecoderFunction
-  onData?(data: Uint8ArrayList): void
-  onLength?(length: number): void
-  maxLengthLength?: number
-  maxDataLength?: number
-}
-
-export interface ReadResult {
-  mode: string
-  chunk?: Uint8ArrayList
-  buffer: Uint8ArrayList
-  state?: ReadState
-  data?: Uint8ArrayList
-}
 
 enum ReadMode {
   LENGTH,

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -4,13 +4,8 @@ import { allocUnsafe } from 'uint8arrays/alloc'
 import { MAX_DATA_LENGTH } from './constants.js'
 import { InvalidDataLengthError } from './errors.js'
 import { isAsyncIterable } from './utils.js'
-import type { LengthEncoderFunction } from './index.js'
+import type { EncoderOptions, LengthEncoderFunction } from './index.js'
 import type { Source } from 'it-stream-types'
-
-interface EncoderOptions {
-  lengthEncoder?: LengthEncoderFunction
-  maxDataLength?: number
-}
 
 // Helper function to validate the chunk size against maxDataLength
 function validateMaxDataLength (chunk: Uint8Array | Uint8ArrayList, maxDataLength: number): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,22 @@ import type { Uint8ArrayList } from 'uint8arraylist'
 export { encode } from './encode.js'
 export { decode } from './decode.js'
 
+export interface DecoderOptions {
+  lengthDecoder?: LengthDecoderFunction
+  onData?(data: Uint8ArrayList): void
+  onLength?(length: number): void
+  maxLengthLength?: number
+  maxDataLength?: number
+}
+
 export interface LengthDecoderFunction {
   (data: Uint8ArrayList): number
   bytes: number
+}
+
+export interface EncoderOptions {
+  lengthEncoder?: LengthEncoderFunction
+  maxDataLength?: number
 }
 
 export interface LengthEncoderFunction {


### PR DESCRIPTION
To enable reuse of the types, export them from the index file.

Also removes some unused types that were not exposed publicly.