### PR TITLE
fix!: Uint8Arrays are generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,17 +174,17 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "it-reader": "^6.0.1",
+    "it-reader": "^7.0.0",
     "it-stream-types": "^2.0.1",
-    "uint8-varint": "^2.0.1",
-    "uint8arraylist": "^2.0.0",
-    "uint8arrays": "^5.0.1"
+    "uint8-varint": "^3.0.0",
+    "uint8arraylist": "^3.0.1",
+    "uint8arrays": "^6.1.0"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "iso-random-stream": "^2.0.0",
     "it-all": "^3.0.0",
-    "it-block": "^6.0.0",
+    "it-block": "^7.0.0",
     "it-drain": "^3.0.0",
     "it-foreach": "^2.0.0",
     "it-map": "^3.0.0",

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -22,10 +22,10 @@ const defaultDecoder: LengthDecoderFunction = (buf) => {
 }
 defaultDecoder.bytes = 0
 
-export function decode (source: Iterable<Uint8ArrayList | Uint8Array>, options?: DecoderOptions): Generator<Uint8ArrayList, void, unknown>
-export function decode (source: Source<Uint8ArrayList | Uint8Array>, options?: DecoderOptions): AsyncGenerator<Uint8ArrayList, void, unknown>
-export function decode (source: Source<Uint8ArrayList | Uint8Array>, options?: DecoderOptions): Generator<Uint8ArrayList, void, unknown> | AsyncGenerator<Uint8ArrayList, void, unknown> {
-  const buffer = new Uint8ArrayList()
+export function decode <T extends ArrayBufferLike = ArrayBufferLike> (source: Iterable<Uint8ArrayList<T> | Uint8Array<T>>, options?: DecoderOptions): Generator<Uint8ArrayList<T>, void, unknown>
+export function decode <T extends ArrayBufferLike = ArrayBufferLike> (source: Source<Uint8ArrayList<T> | Uint8Array<T>>, options?: DecoderOptions): AsyncGenerator<Uint8ArrayList<T>, void, unknown>
+export function decode <T extends ArrayBufferLike = ArrayBufferLike> (source: Source<Uint8ArrayList<T> | Uint8Array<T>>, options?: DecoderOptions): Generator<Uint8ArrayList<T>, void, unknown> | AsyncGenerator<Uint8ArrayList<T>, void, unknown> {
+  const buffer = new Uint8ArrayList<T>()
   let mode = ReadMode.LENGTH
   let dataLength = -1
 
@@ -33,7 +33,7 @@ export function decode (source: Source<Uint8ArrayList | Uint8Array>, options?: D
   const maxLengthLength = options?.maxLengthLength ?? MAX_LENGTH_LENGTH
   const maxDataLength = options?.maxDataLength ?? MAX_DATA_LENGTH
 
-  function * maybeYield (): Generator<Uint8ArrayList> {
+  function * maybeYield (): Generator<Uint8ArrayList<T>> {
     while (buffer.byteLength > 0) {
       if (mode === ReadMode.LENGTH) {
         // read length, ignore errors for short reads

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -5,6 +5,6 @@ export function times <T> (n: number, fn: (...args: any[]) => T): T[] {
   return Array.from(Array(n)).fill(fn())
 }
 
-export function someBytes (n?: number): Uint8Array {
+export function someBytes (n?: number): Uint8Array<ArrayBuffer> {
   return randomBytes(randomInt(1, n ?? 32))
 }


### PR DESCRIPTION
Since microsoft/TypeScript#59417 `Uint8Array`s backed by `ArrayBuffer` are incompatible with those backed with `SharedArrayBuffer` so be explicit about the types returned.

BREAKING CHANGE: the `Uint8ArrayList`s yielded by the Generator returned by the decode function have a generic type that reflects the internal buffer type